### PR TITLE
Cherry-Pick of Oslo library updates

### DIFF
--- a/neutronclient/common/serializer.py
+++ b/neutronclient/common/serializer.py
@@ -21,7 +21,7 @@ import logging
 from xml.etree import ElementTree as etree
 from xml.parsers import expat
 
-from oslo.serialization import jsonutils
+from oslo_serialization import jsonutils
 import six
 
 from neutronclient.common import constants

--- a/neutronclient/common/utils.py
+++ b/neutronclient/common/utils.py
@@ -21,8 +21,8 @@ import argparse
 import logging
 import os
 
-from oslo.utils import encodeutils
-from oslo.utils import importutils
+from oslo_utils import encodeutils
+from oslo_utils import importutils
 import six
 
 from neutronclient.common import exceptions

--- a/neutronclient/i18n.py
+++ b/neutronclient/i18n.py
@@ -10,7 +10,7 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-from oslo import i18n
+import oslo_i18n as i18n
 
 _translators = i18n.TranslatorFactory(domain='neutronclient')
 

--- a/neutronclient/neutron/v2_0/__init__.py
+++ b/neutronclient/neutron/v2_0/__init__.py
@@ -24,7 +24,7 @@ import re
 from cliff.formatters import table
 from cliff import lister
 from cliff import show
-from oslo.serialization import jsonutils
+from oslo_serialization import jsonutils
 import six
 
 from neutronclient.common import command

--- a/neutronclient/neutron/v2_0/port.py
+++ b/neutronclient/neutron/v2_0/port.py
@@ -16,7 +16,7 @@
 
 import argparse
 
-from oslo.serialization import jsonutils
+from oslo_serialization import jsonutils
 
 from neutronclient.common import exceptions
 from neutronclient.common import utils

--- a/neutronclient/neutron/v2_0/quota.py
+++ b/neutronclient/neutron/v2_0/quota.py
@@ -20,7 +20,7 @@ import argparse
 
 from cliff import lister
 from cliff import show
-from oslo.serialization import jsonutils
+from oslo_serialization import jsonutils
 import six
 
 from neutronclient.common import exceptions

--- a/neutronclient/neutron/v2_0/router.py
+++ b/neutronclient/neutron/v2_0/router.py
@@ -18,7 +18,7 @@ from __future__ import print_function
 
 import argparse
 
-from oslo.serialization import jsonutils
+from oslo_serialization import jsonutils
 
 from neutronclient.common import exceptions
 from neutronclient.common import utils

--- a/neutronclient/neutron/v2_0/subnet.py
+++ b/neutronclient/neutron/v2_0/subnet.py
@@ -16,7 +16,7 @@
 
 import argparse
 
-from oslo.serialization import jsonutils
+from oslo_serialization import jsonutils
 
 from neutronclient.common import exceptions
 from neutronclient.common import utils

--- a/neutronclient/neutron/v2_0/vpn/ipsec_site_connection.py
+++ b/neutronclient/neutron/v2_0/vpn/ipsec_site_connection.py
@@ -16,7 +16,7 @@
 # @author: Swaminathan Vasudevan, Hewlett-Packard.
 #
 
-from oslo.serialization import jsonutils
+from oslo_serialization import jsonutils
 
 from neutronclient.common import exceptions
 from neutronclient.common import utils

--- a/neutronclient/shell.py
+++ b/neutronclient/shell.py
@@ -33,7 +33,7 @@ from keystoneclient.auth.identity import v3 as v3_auth
 from keystoneclient import discover
 from keystoneclient.openstack.common.apiclient import exceptions as ks_exc
 from keystoneclient import session
-from oslo.utils import encodeutils
+from oslo_utils import encodeutils
 import six.moves.urllib.parse as urlparse
 
 from cliff import app

--- a/neutronclient/tests/unit/test_auth.py
+++ b/neutronclient/tests/unit/test_auth.py
@@ -19,7 +19,7 @@ import logging
 import uuid
 
 import fixtures
-from oslo.serialization import jsonutils
+from oslo_serialization import jsonutils
 from requests_mock.contrib import fixture as mock_fixture
 import testtools
 

--- a/neutronclient/tests/unit/test_cli20.py
+++ b/neutronclient/tests/unit/test_cli20.py
@@ -20,7 +20,7 @@ import sys
 
 import fixtures
 from mox3 import mox
-from oslo.utils import encodeutils
+from oslo_utils import encodeutils
 from oslotest import base
 import requests
 import six

--- a/neutronclient/tests/unit/test_cli20_agents.py
+++ b/neutronclient/tests/unit/test_cli20_agents.py
@@ -14,7 +14,7 @@
 
 import sys
 
-from oslo.serialization import jsonutils
+from oslo_serialization import jsonutils
 
 from neutronclient.neutron.v2_0 import agent
 from neutronclient.tests.unit import test_cli20

--- a/neutronclient/tests/unit/test_cli20_network.py
+++ b/neutronclient/tests/unit/test_cli20_network.py
@@ -17,7 +17,7 @@ import itertools
 import sys
 
 from mox3 import mox
-from oslo.serialization import jsonutils
+from oslo_serialization import jsonutils
 
 from neutronclient.common import exceptions
 from neutronclient.neutron.v2_0 import network


### PR DESCRIPTION
Installing via pip leads to a broken client since oslo has updated, Cherry-pick the update commit from upstream to allow it to use the non-namespace package names.
